### PR TITLE
Fix breadcrumb navigation to show full path

### DIFF
--- a/src/kernel/common/templates/common/collection_view.html.j2
+++ b/src/kernel/common/templates/common/collection_view.html.j2
@@ -30,15 +30,17 @@
   <nav aria-label="breadcrumb"
        class="navbar-light bg-light sticky-top pb-2 pt-1">
     <div class="text-bg-light me-4">
-      <ol class="breadcrumb">
+     <ol class="breadcrumb">
         <i class="bi bi-boxes"></i>&nbsp;
-        {#<li class="breadcrumb-item">{{ breadcrumbs[0]['label'] }}</li>#}
-        {% for element in breadcrumbs[:-1] %}
+        {% for element in breadcrumbs %}
+          {% if loop.last %}
+          <li class="breadcrumb-item active" aria-current="page">{{ element['label'] }}</li>
+          {% else %}
           <li class="breadcrumb-item">
             <a href="{{ url_for('browse_bp.collection_browse', collection=element['url']) }}">{{ element['label'] }}</a>
           </li>
+          {% endif %}
         {% endfor %}
-        {# <li class="breadcrumb-item active" aria-current="page">{{ breadcrumbs[-1]['label'] }}</li> #}
       </ol>
     </div>
   </nav>


### PR DESCRIPTION
Fix breadcrumb navigation to show full path

Currently, the breadcrumb navigation only displays the path up to the parent directory, with the current directory shown separately in the heading below. This makes it unclear what the complete path is.

This change displays the full hierarchical path in the breadcrumb trail, including the current directory as an active (non-clickable) item.

Changes:
- Include all breadcrumb elements instead of excluding the last one
- Add conditional rendering to mark the last element as active
- Remove commented-out breadcrumb code

This improves navigation clarity by showing the complete path at a glance.